### PR TITLE
Cache the box2d conversion factor on startup

### DIFF
--- a/register_types.cpp
+++ b/register_types.cpp
@@ -16,8 +16,9 @@
 */
 
 void register_godot_box2d_types() {
-	GLOBAL_DEF("physics/2d/box2d_conversion_factor", 50.0f);
-	ProjectSettings::get_singleton()->set_custom_property_info("physics/2d/box2d_conversion_factor", PropertyInfo(Variant::REAL, "physics/2d/box2d_conversion_factor"));
+	GLOBAL_DEF_RST("physics/2d/box2d_conversion_factor", 50.0f);
+	ProjectSettings::get_singleton()->set_custom_property_info("physics/2d/box2d_conversion_factor", PropertyInfo(Variant::REAL, "physics/2d/box2d_conversion_factor", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_RESTART_IF_CHANGED));
+	load_box2d_cached_conversion_factors();
 
 	ClassDB::register_class<Box2DShapeQueryParameters>();
 	ClassDB::register_class<Box2DWorld>();

--- a/util/box2d_types_converter.cpp
+++ b/util/box2d_types_converter.cpp
@@ -6,6 +6,22 @@
 * @author Brian Semrau
 */
 
+static float box2d_conversion_factor = 50.0f;
+static float box2d_conversion_factor_inv = 1.0f / 50.0f;
+
+void load_box2d_cached_conversion_factors() {
+	box2d_conversion_factor = static_cast<float>(GLOBAL_GET("physics/2d/box2d_conversion_factor"));
+	box2d_conversion_factor_inv = 1.0f / static_cast<float>(GLOBAL_GET("physics/2d/box2d_conversion_factor"));
+};
+
+float get_box2d_conversion_factor() {
+	return box2d_conversion_factor;
+}
+
+float get_box2d_conversion_factor_inv() {
+	return box2d_conversion_factor_inv;
+}
+
 // Box2D to Godot
 
 void b2_to_gd(b2Vec2 const &inVal, Vector2 &outVal) {

--- a/util/box2d_types_converter.h
+++ b/util/box2d_types_converter.h
@@ -15,8 +15,12 @@
 * Conversion functions for switching between Box2D/Godot data structures and units.
 */
 
-#define B2_TO_GD static_cast<float>(GLOBAL_GET("physics/2d/box2d_conversion_factor"))
-#define GD_TO_B2 (1.0f / static_cast<float>(GLOBAL_GET("physics/2d/box2d_conversion_factor")))
+extern void load_box2d_cached_conversion_factors();
+extern float get_box2d_conversion_factor();
+extern float get_box2d_conversion_factor_inv();
+
+#define B2_TO_GD get_box2d_conversion_factor()
+#define GD_TO_B2 get_box2d_conversion_factor_inv()
 
 extern void b2_to_gd(b2Vec2 const &inVal, Vector2 &outVal);
 extern Vector2 b2_to_gd(b2Vec2 const &inVal);


### PR DESCRIPTION
probably don't need _any_ of these functions to be `extern` (just move the definition into the header)... does that change anything? would these functions inline better?

also, I did check; it looks like project settings will be loaded before `register_godot_box2d_types` (core does reads settings there too)